### PR TITLE
NG-76 - Support for self-transfer action inference

### DIFF
--- a/src/Common/CoreCommunications/ParsedTransactionMapper.cs
+++ b/src/Common/CoreCommunications/ParsedTransactionMapper.cs
@@ -138,7 +138,7 @@ public class ParsedTransactionMapper<T> : IParsedTransactionMapper
 
         foreach (var summarisation in summarisationsByTransaction.SelectMany(x => x))
         {
-            allValidatorAddressesToLookup.AddRange(summarisation.PendingStakeValidatorAddressesSeen);
+            allValidatorAddressesToLookup.AddRange(summarisation.PreparedUnstakeValidatorAddressesSeen);
         }
 
         var stakeSnapshotLookup = await CreateValidatorAddressStakeSnapshotLookup(allValidatorAddressesToLookup, token);

--- a/src/Common/Database/Models/Ledger/LedgerOperationGroup.cs
+++ b/src/Common/Database/Models/Ledger/LedgerOperationGroup.cs
@@ -104,6 +104,7 @@ public class LedgerOperationGroup
 public enum InferredActionType
 {
     CreateTokenDefinition,
+    SelfTransfer,
     SimpleTransfer,
     StakeTokens,
     UnstakeTokens,
@@ -120,6 +121,7 @@ public class InferredActionTypeValueConverter : EnumTypeValueConverterBase<Infer
     {
         { InferredActionType.CreateTokenDefinition, "CREATE_TOKEN_DEFINITION" },
         { InferredActionType.SimpleTransfer, "SIMPLE_TRANSFER" },
+        { InferredActionType.SelfTransfer, "SELF_TRANSFER" },
         { InferredActionType.StakeTokens, "STAKE_TOKENS" },
         { InferredActionType.UnstakeTokens, "UNSTAKE_TOKENS" },
         { InferredActionType.MintTokens, "MINT_TOKENS" },

--- a/src/DataAggregator/LedgerExtension/TransactionContentProcessor.cs
+++ b/src/DataAggregator/LedgerExtension/TransactionContentProcessor.cs
@@ -908,7 +908,7 @@ public class TransactionContentProcessor
                     amount: TokenAmount.FromSubUnitsString(action.Amount.Value),
                     resource: _dbActionsPlanner.GetLoadedResource(action.Amount.TokenIdentifier.Rri)
                 ),
-                { Type: InferredActionType.SimpleTransfer, Action: Gateway.TransferTokens action } => new InferredAction(
+                { Type: InferredActionType.SimpleTransfer or InferredActionType.SelfTransfer, Action: Gateway.TransferTokens action } => new InferredAction(
                     inferredGatewayAction.Type,
                     fromAccount: _dbActionsPlanner.GetLoadedAccount(action.FromAccount.Address),
                     toAccount: _dbActionsPlanner.GetLoadedAccount(action.ToAccount.Address),

--- a/src/GatewayAPI/Database/TransactionQuerier.cs
+++ b/src/GatewayAPI/Database/TransactionQuerier.cs
@@ -317,6 +317,11 @@ public class TransactionQuerier : ITransactionQuerier
         return inferredAction.Type switch
         {
             InferredActionType.CreateTokenDefinition => await GenerateCreateTokenDefinitionAction(),
+            InferredActionType.SelfTransfer => new Gateway.TransferTokens(
+                fromAccount: inferredAction.FromAccount!.AsGatewayAccountIdentifier(),
+                toAccount: inferredAction.ToAccount!.AsGatewayAccountIdentifier(),
+                amount: inferredAction.Amount!.Value.AsGatewayTokenAmount(inferredAction.Resource!)
+            ),
             InferredActionType.SimpleTransfer => new Gateway.TransferTokens(
                 fromAccount: inferredAction.FromAccount!.AsGatewayAccountIdentifier(),
                 toAccount: inferredAction.ToAccount!.AsGatewayAccountIdentifier(),


### PR DESCRIPTION
Implements Self-Transfer inference. Will want testing on RCNet after merge.

Won't be applied historically, but will work from this point forward after released.