### PR TITLE
NG-39 Index tweaks

### DIFF
--- a/src/Common/Database/CommonDbContext.cs
+++ b/src/Common/Database/CommonDbContext.cs
@@ -288,7 +288,7 @@ public class CommonDbContext : DbContext
 
     private static void HookUpAccountResourceBalanceHistory(ModelBuilder modelBuilder)
     {
-        HookupHistory<ResourceSupplyHistory>(modelBuilder);
+        HookupHistory<AccountResourceBalanceHistory>(modelBuilder);
 
         modelBuilder.Entity<AccountResourceBalanceHistory>()
             .HasKey(h => new { h.AccountId, h.ResourceId, h.FromStateVersion });
@@ -299,8 +299,6 @@ public class CommonDbContext : DbContext
             .IsUnique()
             .HasDatabaseName($"IX_{nameof(AccountResourceBalanceHistory).ToSnakeCase()}_current_balance");
 
-        // All four of these indices (these three plus the implicit index from the PK) could be useful for different queries
-        // TODO:NG-39 Remove any which aren't important for the APIs we're exposing
         modelBuilder.Entity<AccountResourceBalanceHistory>()
             .HasIndex(h => new { h.AccountId, h.FromStateVersion });
         modelBuilder.Entity<AccountResourceBalanceHistory>()
@@ -350,8 +348,6 @@ public class CommonDbContext : DbContext
             .IsUnique()
             .HasDatabaseName($"IX_{nameof(AccountValidatorStakeHistory).ToSnakeCase()}_current_stake");
 
-        // All four of these indices (these three plus the implicit index from the PK) could be useful for different queries
-        // TODO:NG-39 Remove any which aren't important for the APIs we're exposing
         modelBuilder.Entity<AccountValidatorStakeHistory>()
             .HasIndex(h => new { h.AccountId, h.FromStateVersion });
         modelBuilder.Entity<AccountValidatorStakeHistory>()

--- a/src/Common/Database/DbQueryExtensions.cs
+++ b/src/Common/Database/DbQueryExtensions.cs
@@ -357,29 +357,23 @@ INNER JOIN LATERAL (
             .Take(1);
     }
 
-    public static IQueryable<ResourceSupplyHistory> ResourceSupplyHistoryAtVersionForRri<TDbContext>(
+    public static IQueryable<ResourceSupplyHistory> ResourceSupplyHistoryAtVersionForResourceId<TDbContext>(
         this TDbContext dbContext,
         long stateVersion,
-        string rri
+        long resourceId
     )
         where TDbContext : CommonDbContext
     {
-        // NB - other options considered instead of the sub query:
-        // * First do a call to get the resource id, then do this query - but this is 2 round trips
-        // * Using group by - but it's too slow because it doesn't use the indexes :(
-        // * Trying to force a Lateral Join doesn't work as it outputs something else https://github.com/dotnet/efcore/issues/17936
-        // * This variant of the lateral join doesn't work because dbContext.ResourceSupplyHistoryFromResourceIdAtVersion
-        //   doesn't return an IQueryable with a parametrised expression (by resource.Id, say)
-        // return
-        //     from resource in dbContext.Resource(rri, stateVersion)
-        //     from supplyHistory in dbContext.ResourceSupplyHistoryFromResourceIdAtVersion(resource.Id, stateVersion)
-        //     select supplyHistory;
+        /*
+         * NB - I previously tried to merge the rri look-up with this, but no matter the query formulation (eg Lateral Join),
+         * the query planner still often didn't use the right indexes in the right order, resulting in a very slow query
+         * as it would try to parallelize the resource id look up with the supply histoy read, which was super slow for
+         * non-XRD tokens.
+         */
 
         return dbContext.Set<ResourceSupplyHistory>()
             .Where(h =>
-                h.ResourceId == dbContext.Resource(rri, stateVersion)
-                    .Select(r => r.Id)
-                    .FirstOrDefault() // This is actually done in a sub-query server-side.
+                h.ResourceId == resourceId
                 && h.FromStateVersion <= stateVersion
             )
             .OrderByDescending(h => h.FromStateVersion)

--- a/src/DataAggregator/Migrations/20220131143251_FixAccountResourceHistoryForeignKeys.Designer.cs
+++ b/src/DataAggregator/Migrations/20220131143251_FixAccountResourceHistoryForeignKeys.Designer.cs
@@ -68,6 +68,7 @@ using System.Numerics;
 using DataAggregator.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -77,9 +78,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataAggregator.Migrations
 {
     [DbContext(typeof(AggregatorDbContext))]
-    partial class AggregatorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220131143251_FixAccountResourceHistoryForeignKeys")]
+    partial class FixAccountResourceHistoryForeignKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DataAggregator/Migrations/20220131143251_FixAccountResourceHistoryForeignKeys.cs
+++ b/src/DataAggregator/Migrations/20220131143251_FixAccountResourceHistoryForeignKeys.cs
@@ -1,0 +1,126 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAggregator.Migrations
+{
+    public partial class FixAccountResourceHistoryForeignKeys : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_account_resource_balance_history_ledger_transactions_from_s~",
+                table: "account_resource_balance_history");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_account_resource_balance_history_ledger_transactions_to_sta~",
+                table: "account_resource_balance_history");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_account_resource_balance_history_from_transaction",
+                table: "account_resource_balance_history",
+                column: "from_state_version",
+                principalTable: "ledger_transactions",
+                principalColumn: "state_version",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_account_resource_balance_history_to_transaction",
+                table: "account_resource_balance_history",
+                column: "to_state_version",
+                principalTable: "ledger_transactions",
+                principalColumn: "state_version",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_account_resource_balance_history_from_transaction",
+                table: "account_resource_balance_history");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_account_resource_balance_history_to_transaction",
+                table: "account_resource_balance_history");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_account_resource_balance_history_ledger_transactions_from_s~",
+                table: "account_resource_balance_history",
+                column: "from_state_version",
+                principalTable: "ledger_transactions",
+                principalColumn: "state_version",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_account_resource_balance_history_ledger_transactions_to_sta~",
+                table: "account_resource_balance_history",
+                column: "to_state_version",
+                principalTable: "ledger_transactions",
+                principalColumn: "state_version");
+        }
+    }
+}

--- a/src/DataAggregator/Migrations/IdempotentApplyMigrations.sql
+++ b/src/DataAggregator/Migrations/IdempotentApplyMigrations.sql
@@ -968,3 +968,43 @@ BEGIN
 END $EF$;
 COMMIT;
 
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220131143251_FixAccountResourceHistoryForeignKeys') THEN
+    ALTER TABLE account_resource_balance_history DROP CONSTRAINT "FK_account_resource_balance_history_ledger_transactions_from_s~";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220131143251_FixAccountResourceHistoryForeignKeys') THEN
+    ALTER TABLE account_resource_balance_history DROP CONSTRAINT "FK_account_resource_balance_history_ledger_transactions_to_sta~";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220131143251_FixAccountResourceHistoryForeignKeys') THEN
+    ALTER TABLE account_resource_balance_history ADD CONSTRAINT "FK_account_resource_balance_history_from_transaction" FOREIGN KEY (from_state_version) REFERENCES ledger_transactions (state_version) ON DELETE CASCADE;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220131143251_FixAccountResourceHistoryForeignKeys') THEN
+    ALTER TABLE account_resource_balance_history ADD CONSTRAINT "FK_account_resource_balance_history_to_transaction" FOREIGN KEY (to_state_version) REFERENCES ledger_transactions (state_version) ON DELETE RESTRICT;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220131143251_FixAccountResourceHistoryForeignKeys') THEN
+    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220131143251_FixAccountResourceHistoryForeignKeys', '6.0.1');
+    END IF;
+END $EF$;
+COMMIT;
+


### PR DESCRIPTION
* Kept the spare indices as performance is still okay with them
* Fix the naming of the AccountResourceBalanceHistory ledger tranaction FKs
* Fix the token supply call query plan for non-XRD tokens (which we saw be really slow on RCNet)