### PR TITLE
NG-39 - Unminted tokens can be queried/minted

### DIFF
--- a/src/GatewayAPI/Database/TokenQuerier.cs
+++ b/src/GatewayAPI/Database/TokenQuerier.cs
@@ -179,7 +179,8 @@ public class TokenQuerier : ITokenQuerier
 
         if (resourceSupply == null)
         {
-            throw new TokenNotFoundException(resource.ResourceIdentifier);
+            // Mutable supply tokens which have yet to be minted will have no supply history, so return 0 supply for them.
+            return new ResourceSupplyHistory(resource, ResourceSupply.Default());
         }
 
         return resourceSupply;


### PR DESCRIPTION
Fixes a bug where querying the supply of a mutable supply token
which isn't immediately minted returns a 404.

This bug affected both token info and minting.