### PR TITLE
Fix/ng 113 fix configuration bug in dotnet 6 0 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,8 @@ generation/
 .run
 deployment/
 **/*.user
+**/appsettings.DevelopmentOverrides.json
+**/appsettings.ProductionOverrides.json
 
 # DEFAULTS
 **/.dockerignore

--- a/src/DataAggregator/.gitignore
+++ b/src/DataAggregator/.gitignore
@@ -1,1 +1,5 @@
+appsettings.DevelopmentOverrides.json
+appsettings.ProductionOverrides.json
+
+# Old name for DevelopmentOverrides - kept to ensure that it doesn't get source controlled by accident
 appsettings.PersonalOverrides.json

--- a/src/DataAggregator/Program.cs
+++ b/src/DataAggregator/Program.cs
@@ -89,7 +89,7 @@ hostBuilder.ConfigureAppConfiguration((context, config) =>
     if (context.HostingEnvironment.IsDevelopment())
     {
         // As an easier alternative to developer secrets -- this file is in .gitignore to prevent source controlling
-        config.AddJsonFile("appsettings.PersonalOverrides.json", optional: true, reloadOnChange: true);
+        config.AddJsonFile("appsettings.DevelopmentOverrides.json", optional: true, reloadOnChange: true);
     }
     else
     {

--- a/src/DataAggregator/Program.cs
+++ b/src/DataAggregator/Program.cs
@@ -80,6 +80,7 @@ IConfigurationRoot? bootUpConfiguration;
 hostBuilder.ConfigureAppConfiguration((context, config) =>
 {
     config.AddEnvironmentVariables("RADIX_NG_AGGREGATOR__");
+    config.AddEnvironmentVariables("RADIX_NG_AGGREGATOR:"); // Remove this line once https://github.com/dotnet/runtime/issues/61577#issuecomment-1044959384 is fixed
     if (args is { Length: > 0 })
     {
         config.AddCommandLine(args);

--- a/src/DataAggregator/Properties/launchSettings.json
+++ b/src/DataAggregator/Properties/launchSettings.json
@@ -9,6 +9,14 @@
                 "DOTNET_ENVIRONMENT": "Development"
             }
         },
+        "Data Aggregator (Production)": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "applicationUrl": "https://localhost:7214;http://localhost:5207",
+            "environmentVariables": {
+                "DOTNET_ENVIRONMENT": "Production"
+            }
+        },
         "Wipe Database": {
             "commandName": "Project",
             "dotnetRunMessages": true,

--- a/src/GatewayAPI/.gitignore
+++ b/src/GatewayAPI/.gitignore
@@ -1,1 +1,5 @@
+appsettings.DevelopmentOverrides.json
+appsettings.ProductionOverrides.json
+
+# Old name for DevelopmentOverrides - kept to ensure that it doesn't get source controlled by accident
 appsettings.PersonalOverrides.json

--- a/src/GatewayAPI/Program.cs
+++ b/src/GatewayAPI/Program.cs
@@ -80,6 +80,7 @@ var hostBuilder = builder.Host;
 hostBuilder.ConfigureAppConfiguration((context, config) =>
 {
     config.AddEnvironmentVariables("RADIX_NG_API__");
+    config.AddEnvironmentVariables("RADIX_NG_API:"); // Remove this line once https://github.com/dotnet/runtime/issues/61577#issuecomment-1044959384 is fixed
     if (args is { Length: > 0 })
     {
         config.AddCommandLine(args);

--- a/src/GatewayAPI/Program.cs
+++ b/src/GatewayAPI/Program.cs
@@ -89,7 +89,7 @@ hostBuilder.ConfigureAppConfiguration((context, config) =>
     if (context.HostingEnvironment.IsDevelopment())
     {
         // As an easier alternative to developer secrets -- this file is in .gitignore to prevent source controlling
-        config.AddJsonFile("appsettings.PersonalOverrides.json", optional: true, reloadOnChange: true);
+        config.AddJsonFile("appsettings.DevelopmentOverrides.json", optional: true, reloadOnChange: true);
     }
     else
     {

--- a/src/GatewayAPI/Properties/launchSettings.json
+++ b/src/GatewayAPI/Properties/launchSettings.json
@@ -10,6 +10,16 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
             }
+        },
+        "Gateway API (Production)": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "launchUrl": "swagger",
+            "applicationUrl": "https://localhost:7215;http://localhost:5208",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Production"
+            }
         }
     }
 }


### PR DESCRIPTION
See also: https://github.com/dotnet/runtime/issues/61577#issuecomment-1044959384

This was causing an exception on start-up when run with ASP Net runtime 6.0.2 (which is being pulled in automatically by the 6.0 docker label). I'd prefer not to pull in patch updates where we can (so that we do pull in security fixes), so I've added a workaround I discovered.

The following exception is the one I was talking about:
```Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'connectionString')```

The actual fix is just in the first commit: https://github.com/radixdlt/radixdlt-network-gateway/pull/35/commits/c5f7ce1f144309d2b9147dc3a5dc10f86ac415db the second commit is just some improvements to running it locally for development to allow us to debug production builds more easily.

This change should let us deploy correctly to stokenet. I'll create a 1.1.1 release on Monday once this is merged...