### PR TITLE
Add configuration for assertion types

### DIFF
--- a/src/DataAggregator/GlobalServices/LedgerExtenderService.cs
+++ b/src/DataAggregator/GlobalServices/LedgerExtenderService.cs
@@ -104,6 +104,7 @@ public record CommitTransactionsReport(
 
 public class LedgerExtenderService : ILedgerExtenderService
 {
+    private readonly IConfiguration _configuration;
     private readonly ILogger<LedgerExtenderService> _logger;
     private readonly IDbContextFactory<AggregatorDbContext> _dbContextFactory;
     private readonly IRawTransactionWriter _rawTransactionWriter;
@@ -119,6 +120,7 @@ public class LedgerExtenderService : ILedgerExtenderService
     );
 
     public LedgerExtenderService(
+        IConfiguration configuration,
         ILogger<LedgerExtenderService> logger,
         IDbContextFactory<AggregatorDbContext> dbContextFactory,
         IRawTransactionWriter rawTransactionWriter,
@@ -127,6 +129,7 @@ public class LedgerExtenderService : ILedgerExtenderService
         INetworkConfigurationProvider networkConfigurationProvider
     )
     {
+        _configuration = configuration;
         _logger = logger;
         _dbContextFactory = dbContextFactory;
         _rawTransactionWriter = rawTransactionWriter;
@@ -276,7 +279,7 @@ public class LedgerExtenderService : ILedgerExtenderService
         CancellationToken cancellationToken
     )
     {
-        var dbActionsPlanner = new DbActionsPlanner(dbContext, _entityDeterminer, cancellationToken);
+        var dbActionsPlanner = new DbActionsPlanner(_configuration, dbContext, _entityDeterminer, cancellationToken);
 
         var transactionContentProcessingMs = CodeStopwatch.TimeInMs(
             () => ProcessTransactions(dbContext, dbActionsPlanner, transactions)

--- a/src/DataAggregator/LedgerExtension/DbActionsPlanner.cs
+++ b/src/DataAggregator/LedgerExtension/DbActionsPlanner.cs
@@ -114,6 +114,7 @@ public record ActionsPlannerReport(
 /// </summary>
 public class DbActionsPlanner
 {
+    private readonly IConfiguration _configuration;
     private readonly AggregatorDbContext _dbContext;
     private readonly IEntityDeterminer _entityDeterminer;
     private readonly CancellationToken _cancellationToken;
@@ -148,8 +149,9 @@ public class DbActionsPlanner
     private Dictionary<Validator, ValidatorStakeHistory>? _latestValidatorStakeHistory;
     private Dictionary<AccountValidator, AccountValidatorStakeHistory>? _latestAccountValidatorStakeHistory;
 
-    public DbActionsPlanner(AggregatorDbContext dbContext, IEntityDeterminer entityDeterminer, CancellationToken cancellationToken)
+    public DbActionsPlanner(IConfiguration configuration, AggregatorDbContext dbContext, IEntityDeterminer entityDeterminer, CancellationToken cancellationToken)
     {
+        _configuration = configuration;
         _dbContext = dbContext;
         _entityDeterminer = entityDeterminer;
         _cancellationToken = cancellationToken;
@@ -555,7 +557,10 @@ public class DbActionsPlanner
             );
         }
 
-        if (!verifySubstateMatches(substate))
+        if (
+            _configuration.GetValue<bool>("TransactionAssertions:AssertDownedSubstatesMatchDownFromCoreApi")
+            && !verifySubstateMatches(substate)
+        )
         {
             throw new InvalidTransactionException(
                 transactionOpLocator,

--- a/src/DataAggregator/appsettings.json
+++ b/src/DataAggregator/appsettings.json
@@ -32,6 +32,9 @@
         "MaxCommitBatchSize": 1000,
         "MaxTransactionPipelineSizePerNode": 3000
     },
+    "TransactionAssertions": {
+        "AssertDownedSubstatesMatchDownFromCoreApi": false,
+    },
     "PrometheusMetricsPort": 1234,
     "WaitMsOnStartUp": 0, // In case we need to wait for PostgreSQL to come up
     "NetworkName": "mainnet",


### PR DESCRIPTION
This commit also disables the assertion that the Core API reconstructed down substate data matches exactly with the Gateway DB before downing.

This appears to be spuriously triggering when certain validator data is downed, due to incorrect rebuilding of this downed substate data for comparison.