### PR TITLE
Improved worker/initializer logging on error

### DIFF
--- a/src/DataAggregator/GlobalWorkers/NodeConfigurationMonitorWorker.cs
+++ b/src/DataAggregator/GlobalWorkers/NodeConfigurationMonitorWorker.cs
@@ -62,10 +62,8 @@
  * permissions under this License.
  */
 
-using Common.Extensions;
 using DataAggregator.Configuration;
 using DataAggregator.GlobalServices;
-using NodaTime;
 
 namespace DataAggregator.GlobalWorkers;
 
@@ -97,13 +95,15 @@ public class NodeConfigurationMonitorWorker : GlobalWorker
 
     protected override async Task OnStoppedSuccessfully()
     {
-        _logger.LogInformation("Received cancellation at: {Time} - instructing all node workers to stop", SystemClock.Instance.GetCurrentInstant().AsUtcIsoDateToSecondsForLogs());
+        _logger.LogInformation("Service execution has stopped - now instructing all node workers to stop");
 
         using var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.CancelAfter(TimeSpan.FromMilliseconds(1000));
         await _nodeWorkersRunnerRegistry.StopAllWorkers(cancellationTokenSource.Token);
 
         _logger.LogInformation("All node workers have been stopped");
+
+        await base.OnStoppedSuccessfully();
     }
 
     private async Task HandleNodeConfiguration(CancellationToken stoppingToken)

--- a/src/DataAggregator/NodeScopedServices/NodeNetworkConfigurationInitializer.cs
+++ b/src/DataAggregator/NodeScopedServices/NodeNetworkConfigurationInitializer.cs
@@ -63,7 +63,6 @@
  */
 
 using Common.Addressing;
-using Common.Database.Models;
 using Common.Database.Models.SingleEntries;
 using DataAggregator.Configuration;
 using DataAggregator.Exceptions;
@@ -73,7 +72,7 @@ using RadixCoreApi.Generated.Model;
 
 namespace DataAggregator.NodeScopedServices;
 
-public class NodeNetworkConfigurationInitializer : INodeInitializer
+public class NodeNetworkConfigurationInitializer : NodeInitializer
 {
     private readonly IAggregatorConfiguration _configuration;
     private readonly INetworkConfigurationReader _networkConfigurationReader;
@@ -81,11 +80,13 @@ public class NodeNetworkConfigurationInitializer : INodeInitializer
     private readonly ILogger<NodeNetworkConfigurationInitializer> _logger;
 
     public NodeNetworkConfigurationInitializer(
+        INodeConfigProvider nodeConfigProvider,
         IAggregatorConfiguration configuration,
         INetworkConfigurationReader networkConfigurationReader,
         INetworkConfigurationProvider networkConfigurationProvider,
         ILogger<NodeNetworkConfigurationInitializer> logger
     )
+        : base(nodeConfigProvider.NodeAppSettings.Name)
     {
         _configuration = configuration;
         _networkConfigurationReader = networkConfigurationReader;
@@ -93,7 +94,7 @@ public class NodeNetworkConfigurationInitializer : INodeInitializer
         _logger = logger;
     }
 
-    public async Task Initialize(CancellationToken token)
+    protected override async Task Initialize(CancellationToken token)
     {
         var networkConfiguration = await ReadNetworkConfigurationFromNode(token);
 

--- a/src/DataAggregator/NodeScopedServices/NodeWorkersRunner.cs
+++ b/src/DataAggregator/NodeScopedServices/NodeWorkersRunner.cs
@@ -200,7 +200,7 @@ public class NodeWorkersRunner : IDisposable
 
         try
         {
-            await Task.WhenAll(_initializers.Select(i => i.Initialize(combinedCancellationToken)));
+            await Task.WhenAll(_initializers.Select(i => i.Run(combinedCancellationToken)));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Tightened up error handling for worker and initialiser errors, to ensure all the cases are handled appropriately and adequately logged and monitored via metrics, to understand how/why services are stopped.