### PR TITLE
[DO-412] Add a release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+#This configuration needs to be in the default repository branch
+template: |
+  ## Changes
+  $CHANGES
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'task'
+      - 'refactor'
+  - title: '📚 Documentation'
+    labels:
+      - 'docs'
+  - title: '🥂 Improvements'
+    labels:
+      - 'performance'
+      - 'test'
+
+  - title: '🍏 CI & Build'
+    labels:
+      - 'ci'
+      - 'build'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch

--- a/.github/workflows/release-drafter-reusable.yml
+++ b/.github/workflows/release-drafter-reusable.yml
@@ -1,0 +1,12 @@
+name: Re-usable Release Drafter
+
+on:
+  workflow_call:
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 on:
  push:
    branches:
-     - DO-412-release-drafter
+     - main
 jobs:
   release-drafter:
     uses: ./.github/workflows/release-drafter-reusable.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,4 +5,4 @@ on:
      - DO-412-release-drafter
 jobs:
   release-drafter:
-    uses: ./.github/workflows/release-drafter-reusable.yml@DO-412-release-drafter
+    uses: ./.github/workflows/release-drafter-reusable.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,4 +5,4 @@ on:
      - DO-412-release-drafter
 jobs:
   release-drafter:
-    uses: .github/workflows/release-drafter-reusable.yml@DO-412-release-drafter
+    uses: ./.github/workflows/release-drafter-reusable.yml@DO-412-release-drafter

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,8 @@
+name: Release Drafter
+on:
+ push:
+   branches:
+     - DO-412-release-drafter
+jobs:
+  release-drafter:
+    uses: .github/workflows/release-drafter-reusable.yml@DO-412-release-drafter


### PR DESCRIPTION
- Add a release drafter workflow
- The release drafter is configured to be re-usable(can be used by other repositories)

Example:
<img width="810" alt="Screenshot 2022-03-24 at 11 21 57" src="https://user-images.githubusercontent.com/11340190/159873119-8ef75b11-8634-4397-baf4-aed8988e8394.png">
