### PR TITLE
Create database migrations bundle during docker build

### DIFF
--- a/src/DataAggregator/Dockerfile
+++ b/src/DataAggregator/Dockerfile
@@ -10,6 +10,8 @@ EXPOSE 1235
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY . .
+RUN dotnet tool install --global dotnet-ef
+RUN PATH="$PATH:$HOME/.dotnet/tools" dotnet ef migrations bundle --project src/DataAggregator --verbose
 RUN dotnet restore "src/DataAggregator/DataAggregator.csproj"
 RUN dotnet build "src/DataAggregator/DataAggregator.csproj" -c Release -o /app/build
 

--- a/src/DataAggregator/Dockerfile
+++ b/src/DataAggregator/Dockerfile
@@ -21,4 +21,5 @@ RUN dotnet publish "src/DataAggregator/DataAggregator.csproj" -c Release -o /app
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY --from=build /src/efbundle .
 ENTRYPOINT ["dotnet", "DataAggregator.dll"]


### PR DESCRIPTION
The bundle needs the sdk in order to be created which isn't available on the final image.