### PR TITLE
Separate the workflows for PRs, releases and the main branch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
-name: main
+name: pull-request
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
@@ -27,16 +27,16 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-latest
-    environment: release
     outputs:
-      data-aggregator-tag: ${{ steps.setup_tags.outputs.data-aggregator-tag}}
-      gateway-api-tag: ${{ steps.setup_tags.outputs.gateway-api-tag}}
+      data-aggregator-tag: ${{ steps.setup_tags.outputs.data-aggregator-tag }}
+      gateway-api-tag: ${{ steps.setup_tags.outputs.gateway-api-tag }}
     steps:
       - name: Dump context
         uses: crazy-max/ghaction-dump-context@v1
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Login to GCR
         uses: docker/login-action@v1
@@ -70,14 +70,19 @@ jobs:
           push: true
           context: ./
 
-  deploy-on-sandpitnet:
+  # TODO: Only radixdlt members to trigger these events
+  deploy-pr:
     runs-on: ubuntu-latest
     needs: publish-docker
     steps:
-      - name: Trigger deployment event ${{ github.ref }}
+      - name: setup "namespace_postfix"
+        run: |
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          echo "NAMESPACE=pr-$pull_number" >> $GITHUB_ENV
+
+      - name: Trigger pull request deployment event ${{ github.ref }}
         env:
-          NAMESPACE: "sandpitnet"
-          EVENT_TYPE: "ng_dev"
+          EVENT_TYPE: "ng_pr"
         run: |
           curl --silent --show-error --fail --location --request POST 'https://github-worker.radixdlt.com/repos/radixdlt/${{secrets.DISPATCH_REPO}}/dispatches' \
             --header 'Accept: application/vnd.github.v3+json' \
@@ -91,4 +96,3 @@ jobs:
                     "gateway_api_image_tag": "${{ needs.publish-docker.outputs.gateway-api-tag }}"
                 }
             }'
-

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,4 +1,4 @@
-name: build-publish-dotnet-binary
+name: release
 on:
   release:
     types: [published]
@@ -28,8 +28,8 @@ jobs:
           cd ../GatewayAPI
           echo "$( jq '.+{GatewayApiVersion:"${{ steps.get_release.outputs.tag_name }}"}' appsettings.json )" > appsettings.json
           dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
-          cd ../..          
-          
+          cd ../..
+
           zip -r data-aggregator.zip src/DataAggregator/output/
           zip -r gateway-api.zip src/GatewayAPI/output/
       - name: Upload DataAggreagtor zip
@@ -51,4 +51,43 @@ jobs:
           asset_name: gateway-api-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
 
-  
+  publish-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@v1
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Login to Dockerhub (release)
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Setup tags for docker image
+        id: setup_tags
+        uses: ./.github/actions/set-variables
+        with:
+          github_event_name: ${{ github.event_name }}
+          github_action_name: ${{ github.event.action}}
+
+      - name: Docker build and push DataAggregator
+        uses: docker/build-push-action@v2
+        with:
+          file: ./src/DataAggregator/Dockerfile
+          TAGS: |
+            ${{ steps.setup_tags.outputs.data_aggregator_tags }}
+          push: true
+          context: ./
+
+      - name: Docker build and push Gateway API
+        uses: docker/build-push-action@v2
+        with:
+          file: ./src/GatewayAPI/Dockerfile
+          TAGS: |
+            ${{ steps.setup_tags.outputs.gateway_api_tags }}
+          push: true
+          context: ./


### PR DESCRIPTION
The current separation makes it easier to follow the jobs for each scenario without having to juggle through all the different `if` statements that were used.