### PR TITLE
NT-302 - Track candidate fork votes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Custom gitignore
 .postgresdata/
-.postgresdata_backup/
+.postgresdata_backup*/
 
 # Rider gitignore
 

--- a/.idea/.idea.radixdlt-network-gateway/.idea/misc.xml
+++ b/.idea/.idea.radixdlt-network-gateway/.idea/misc.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SwUserDefinedSpecifications">
+    <option name="specTypeByUrl">
+      <map />
+    </option>
+  </component>
+</project>

--- a/src/Common/Database/CommonDbContext.cs
+++ b/src/Common/Database/CommonDbContext.cs
@@ -80,6 +80,8 @@ namespace Common.Database;
 
 /// <summary>
 /// Common DB Context for the Network Gateway database.
+///
+/// After updating this file, run ./generation/generate-migration.sh.
 /// </summary>
 public class CommonDbContext : DbContext
 {
@@ -106,6 +108,8 @@ public class CommonDbContext : DbContext
     public DbSet<ResourceDataSubstate> ResourceDataSubstates => Set<ResourceDataSubstate>();
 
     public DbSet<ValidatorDataSubstate> ValidatorDataSubstates => Set<ValidatorDataSubstate>();
+
+    public DbSet<ValidatorSystemMetadataSubstate> ValidatorSystemMetadataSubstates => Set<ValidatorSystemMetadataSubstate>();
 
     public DbSet<AccountResourceBalanceHistory> AccountResourceBalanceHistoryEntries => Set<AccountResourceBalanceHistory>();
 
@@ -266,6 +270,7 @@ public class CommonDbContext : DbContext
         // Data substates
         HookUpSubstate<ResourceDataSubstate>(modelBuilder);
         HookUpSubstate<ValidatorDataSubstate>(modelBuilder);
+        HookUpSubstate<ValidatorSystemMetadataSubstate>(modelBuilder);
     }
 
     private static void HookupHistory(ModelBuilder modelBuilder)

--- a/src/Common/Database/Models/Ledger/Substates/ValidatorSystemMetadataSubstate.cs
+++ b/src/Common/Database/Models/Ledger/Substates/ValidatorSystemMetadataSubstate.cs
@@ -84,7 +84,7 @@ public class ValidatorSystemMetadataSubstate : DataSubstateBase
     [ForeignKey(nameof(ValidatorId))]
     public Validator Validator { get; set; }
 
-    // These are all [Owned] types below - exactly one of these will be present on each
+    // This is [Owned] below
     public ValidatorCandidateForkVote? ValidatorCandidateForkVote { get; set; }
 
     /// <summary>
@@ -126,8 +126,8 @@ public record ValidatorCandidateForkVote
     [Column(name: "fork_id")]
     public byte[]? ForkId { get; set; }
 
-    [Column(name: "nonce")]
-    public byte[]? Nonce { get; set; }
+    [Column(name: "nonce_hash")]
+    public byte[]? NonceHash { get; set; }
 
     public static ValidatorCandidateForkVote From(Core.ValidatorSystemMetadata apiModel)
     {
@@ -148,14 +148,14 @@ public record ValidatorCandidateForkVote
         // See CandidateForkVote in the Java Repo
         var forkName = ExtractForkName(fullBytes[..16]);
         var forkId = fullBytes[..24];
-        var nonce = fullBytes[24..32];
+        var nonceHash = fullBytes[24..32];
 
         return new ValidatorCandidateForkVote
         {
             FullBytes = fullBytes,
             ForkName = forkName,
             ForkId = forkId,
-            Nonce = nonce,
+            NonceHash = nonceHash,
         };
     }
 
@@ -168,7 +168,7 @@ public record ValidatorCandidateForkVote
         }
         catch (ArgumentException)
         {
-            // The byte array contains invalid Unicode code points.
+            // The byte array contains invalid code points.
             // See: https://docs.microsoft.com/en-us/dotnet/api/System.Text.Encoding.GetString?view=net-6.0
             return null;
         }

--- a/src/DataAggregator/GlobalServices/LedgerExtenderService.cs
+++ b/src/DataAggregator/GlobalServices/LedgerExtenderService.cs
@@ -66,6 +66,7 @@ using Common.CoreCommunications;
 using Common.Database.Models.Ledger;
 using Common.Database.Models.SingleEntries;
 using Common.Utilities;
+using DataAggregator.Configuration;
 using DataAggregator.DependencyInjection;
 using DataAggregator.LedgerExtension;
 using Microsoft.EntityFrameworkCore;
@@ -104,7 +105,7 @@ public record CommitTransactionsReport(
 
 public class LedgerExtenderService : ILedgerExtenderService
 {
-    private readonly IConfiguration _configuration;
+    private readonly IAggregatorConfiguration _configuration;
     private readonly ILogger<LedgerExtenderService> _logger;
     private readonly IDbContextFactory<AggregatorDbContext> _dbContextFactory;
     private readonly IRawTransactionWriter _rawTransactionWriter;
@@ -120,7 +121,7 @@ public class LedgerExtenderService : ILedgerExtenderService
     );
 
     public LedgerExtenderService(
-        IConfiguration configuration,
+        IAggregatorConfiguration configuration,
         ILogger<LedgerExtenderService> logger,
         IDbContextFactory<AggregatorDbContext> dbContextFactory,
         IRawTransactionWriter rawTransactionWriter,
@@ -279,7 +280,12 @@ public class LedgerExtenderService : ILedgerExtenderService
         CancellationToken cancellationToken
     )
     {
-        var dbActionsPlanner = new DbActionsPlanner(_configuration, dbContext, _entityDeterminer, cancellationToken);
+        var dbActionsPlanner = new DbActionsPlanner(
+            _configuration.GetTransactionAssertionConfiguration(),
+            dbContext,
+            _entityDeterminer,
+            cancellationToken
+        );
 
         var transactionContentProcessingMs = CodeStopwatch.TimeInMs(
             () => ProcessTransactions(dbContext, dbActionsPlanner, transactions)

--- a/src/DataAggregator/Migrations/20220427122411_AddValidatorSystemMetadataSubstates.Designer.cs
+++ b/src/DataAggregator/Migrations/20220427122411_AddValidatorSystemMetadataSubstates.Designer.cs
@@ -68,6 +68,7 @@ using System.Numerics;
 using DataAggregator.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -77,9 +78,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataAggregator.Migrations
 {
     [DbContext(typeof(AggregatorDbContext))]
-    partial class AggregatorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220427122411_AddValidatorSystemMetadataSubstates")]
+    partial class AddValidatorSystemMetadataSubstates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DataAggregator/Migrations/20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName.Designer.cs
+++ b/src/DataAggregator/Migrations/20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName.Designer.cs
@@ -68,6 +68,7 @@ using System.Numerics;
 using DataAggregator.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -77,9 +78,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataAggregator.Migrations
 {
     [DbContext(typeof(AggregatorDbContext))]
-    partial class AggregatorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName")]
+    partial class UpdateValidatorSystemMetadataSubstateNonceHashName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DataAggregator/Migrations/20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName.cs
+++ b/src/DataAggregator/Migrations/20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName.cs
@@ -62,44 +62,28 @@
  * permissions under this License.
  */
 
-using System.Collections.Immutable;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace DataAggregator.Configuration.Models;
+#nullable disable
 
-public record TransactionAssertionConfiguration
+namespace DataAggregator.Migrations
 {
-    /// <summary>
-    /// Due to changes of parsing certain Core API responses by the Open API library between before/after the 1.1.1
-    /// release, we disable this matching check by default. This can be re-enabled if re-syncing from scratch.
-    /// </summary>
-    [ConfigurationKeyName("AssertDownedSubstatesMatchDownFromCoreApi")]
-    public bool AssertDownedSubstatesMatchDownFromCoreApi { get; set; } = false;
-
-    /// <summary>
-    /// Some releases of the Gateway API have included tracking of new substates.
-    /// This configuration option allows Gateway runners to upgrade late to these releases without breaking.
-    /// Specifically, this option allows substates to be DOWN'd without having seen the substate previously been UP'd.
-    /// Use the value "" to override this default configuration to not permit any inaccurate substate history.
-    ///
-    /// Note - we use a comma separated string instead of a list as it can be overriden better.
-    /// DotNet configuration of enumerables only supports merging which we don't want... (and empty arrays count as
-    /// "null") - see also https://github.com/dotnet/runtime/issues/36384.
-    /// </summary>
-    [ConfigurationKeyName("SubstateTypesWhichAreAllowedToHaveIncompleteHistoryCommaSeparated")]
-    public string SubstateTypesWhichAreAllowedToHaveIncompleteHistoryCommaSeparated { get; set; } = "ValidatorSystemMetadataSubstate";
-
-    private IReadOnlyList<string>? _cachedSubstateTypesWhichAreAllowedToHaveIncompleteHistory;
-
-    // This gets cached when called for the first time
-    public IReadOnlyList<string> SubstateTypesWhichAreAllowedToHaveIncompleteHistory =>
-        _cachedSubstateTypesWhichAreAllowedToHaveIncompleteHistory ??=
-            SplitCommaSeparatedList(SubstateTypesWhichAreAllowedToHaveIncompleteHistoryCommaSeparated);
-
-    private IReadOnlyList<string> SplitCommaSeparatedList(string list)
+    public partial class UpdateValidatorSystemMetadataSubstateNonceHashName : Migration
     {
-        return list.Split(",")
-            .Select(s => s.Trim())
-            .Where(s => !string.IsNullOrEmpty(s))
-            .ToImmutableList();
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "nonce",
+                table: "validator_system_metadata_substates",
+                newName: "nonce_hash");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "nonce_hash",
+                table: "validator_system_metadata_substates",
+                newName: "nonce");
+        }
     }
 }

--- a/src/DataAggregator/Migrations/IdempotentApplyMigrations.sql
+++ b/src/DataAggregator/Migrations/IdempotentApplyMigrations.sql
@@ -1059,3 +1059,22 @@ BEGIN
 END $EF$;
 COMMIT;
 
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName') THEN
+    ALTER TABLE validator_system_metadata_substates RENAME COLUMN nonce TO nonce_hash;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName') THEN
+    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220428101716_UpdateValidatorSystemMetadataSubstateNonceHashName', '6.0.1');
+    END IF;
+END $EF$;
+COMMIT;
+

--- a/src/DataAggregator/Migrations/IdempotentApplyMigrations.sql
+++ b/src/DataAggregator/Migrations/IdempotentApplyMigrations.sql
@@ -1008,3 +1008,54 @@ BEGIN
 END $EF$;
 COMMIT;
 
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220427122411_AddValidatorSystemMetadataSubstates') THEN
+    CREATE TABLE validator_system_metadata_substates (
+        up_state_version bigint NOT NULL,
+        up_operation_group_index integer NOT NULL,
+        up_operation_index_in_group integer NOT NULL,
+        validator_id bigint NOT NULL,
+        full_bytes bytea NULL,
+        fork_name text NULL,
+        fork_id bytea NULL,
+        nonce bytea NULL,
+        down_state_version bigint NULL,
+        down_operation_group_index integer NULL,
+        down_operation_index_in_group integer NULL,
+        substate_identifier bytea NOT NULL,
+        CONSTRAINT "PK_validator_system_metadata_substates" PRIMARY KEY (up_state_version, up_operation_group_index, up_operation_index_in_group),
+        CONSTRAINT "AK_validator_system_metadata_substates_substate_identifier" UNIQUE (substate_identifier),
+        CONSTRAINT "FK_validator_system_metadata_substate_down_operation_group" FOREIGN KEY (down_state_version, down_operation_group_index) REFERENCES operation_groups (state_version, operation_group_index) ON DELETE RESTRICT,
+        CONSTRAINT "FK_validator_system_metadata_substate_up_operation_group" FOREIGN KEY (up_state_version, up_operation_group_index) REFERENCES operation_groups (state_version, operation_group_index) ON DELETE CASCADE,
+        CONSTRAINT "FK_validator_system_metadata_substates_validators_validator_id" FOREIGN KEY (validator_id) REFERENCES validators (id) ON DELETE CASCADE
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220427122411_AddValidatorSystemMetadataSubstates') THEN
+    CREATE INDEX "IX_validator_system_metadata_substates_down_state_version_down~" ON validator_system_metadata_substates (down_state_version, down_operation_group_index);
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220427122411_AddValidatorSystemMetadataSubstates') THEN
+    CREATE INDEX "IX_validator_system_metadata_substates_validator_id" ON validator_system_metadata_substates (validator_id);
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220427122411_AddValidatorSystemMetadataSubstates') THEN
+    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220427122411_AddValidatorSystemMetadataSubstates', '6.0.1');
+    END IF;
+END $EF$;
+COMMIT;
+

--- a/src/DataAggregator/Workers/ExponentialBackoffDelayBetweenLoopsStrategy.cs
+++ b/src/DataAggregator/Workers/ExponentialBackoffDelayBetweenLoopsStrategy.cs
@@ -1,3 +1,67 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
 namespace DataAggregator.Workers;
 
 public class ExponentialBackoffDelayBetweenLoopsStrategy : IDelayBetweenLoopsStrategy

--- a/src/DataAggregator/Workers/IDelayBetweenLoopsStrategy.cs
+++ b/src/DataAggregator/Workers/IDelayBetweenLoopsStrategy.cs
@@ -1,3 +1,67 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
 namespace DataAggregator.Workers;
 
 public interface IDelayBetweenLoopsStrategy

--- a/src/DataAggregator/appsettings.json
+++ b/src/DataAggregator/appsettings.json
@@ -27,7 +27,8 @@
         "MaxTransactionPipelineSizePerNode": 3000
     },
     "TransactionAssertions": {
-        "AssertDownedSubstatesMatchDownFromCoreApi": false
+        "AssertDownedSubstatesMatchDownFromCoreApi": false,
+        "SubstateTypesWhichAreAllowedToHaveIncompleteHistoryCommaSeparated": "ValidatorSystemMetadataSubstate"
     },
     "PrometheusMetricsPort": 1234,
     "WaitMsOnStartUp": 0,

--- a/src/Tests/MiniUnitTests/DataAggregator/Workers/ExponentialBackoffDelayBetweenLoopsStrategyTests.cs
+++ b/src/Tests/MiniUnitTests/DataAggregator/Workers/ExponentialBackoffDelayBetweenLoopsStrategyTests.cs
@@ -1,3 +1,67 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
 using DataAggregator.Workers;
 using Xunit;
 


### PR DESCRIPTION
Includes allowing only partial history for these substates - to support people upgrading too late after having missed some votes - without needing them to resync. In this case, a DOWN without a matching UP in the database won't be a fatal error - instead, it will create the substate record in the database, but set the up state version / operation group / operation to match the down.

For people who care about having a complete history, they can set `TransactionAssertions.SubstateTypesWhichAreAllowedToHaveIncompleteHistoryCommaSeparated` to an empty string, and resync their Gateway from scratch.

Have tested the following:
* Syncing the votes from milestonenet and checking the database is accurate
* Enabling vote syncing from milestonenet half way through, and ingested some DOWNs which didn't have corresponding UPs in the database (resulting in incomplete data)