### PR TITLE
Feature/ng 109 validation improvements

### DIFF
--- a/src/GatewayAPI/ApiSurface/Validations.cs
+++ b/src/GatewayAPI/ApiSurface/Validations.cs
@@ -229,7 +229,17 @@ public class Validations : IValidations
         var tokenAmount = Common.Numerics.TokenAmount.FromSubUnitsString(actionAmount.Value);
         if (tokenAmount.IsNaN())
         {
-            InvalidRequestException.FromOtherError("Token amount value could not be parsed");
+            if (actionAmount.Value.Contains('.'))
+            {
+                InvalidRequestException.FromOtherError(
+                    "Token amount value could not be parsed." +
+                    "Note, that the value is denominated in attos (smallest unit of XRD, 1 XRD = 10^18 attos). " +
+                    "Attos are indivisible and therefore the value can't contain a decimal point.");
+            }
+            else
+            {
+                InvalidRequestException.FromOtherError("Token amount value could not be parsed");
+            }
         }
 
         return new ValidatedTokenAmount(validatedResourceAddress.Rri, tokenAmount, validatedResourceAddress.ResourceAddress);

--- a/src/GatewayAPI/ApiSurface/Validations.cs
+++ b/src/GatewayAPI/ApiSurface/Validations.cs
@@ -231,15 +231,13 @@ public class Validations : IValidations
         {
             if (actionAmount.Value.Contains('.'))
             {
-                InvalidRequestException.FromOtherError(
-                    "Token amount value could not be parsed." +
+                throw InvalidRequestException.FromOtherError(
+                    "Token amount value could not be parsed. " +
                     "Note, that the value is denominated in attos (smallest unit of XRD, 1 XRD = 10^18 attos). " +
                     "Attos are indivisible and therefore the value can't contain a decimal point.");
             }
-            else
-            {
-                InvalidRequestException.FromOtherError("Token amount value could not be parsed");
-            }
+
+            throw InvalidRequestException.FromOtherError("Token amount value could not be parsed");
         }
 
         return new ValidatedTokenAmount(validatedResourceAddress.Rri, tokenAmount, validatedResourceAddress.ResourceAddress);

--- a/src/GatewayAPI/Controllers/TokenController.cs
+++ b/src/GatewayAPI/Controllers/TokenController.cs
@@ -65,11 +65,9 @@
 using Common.Addressing;
 using GatewayAPI.ApiSurface;
 using GatewayAPI.Database;
-using GatewayAPI.Exceptions;
 using GatewayAPI.Services;
 using Microsoft.AspNetCore.Mvc;
 using RadixGatewayApi.Generated.Model;
-using System.Text.RegularExpressions;
 
 namespace GatewayAPI.Controllers;
 
@@ -77,8 +75,6 @@ namespace GatewayAPI.Controllers;
 [Route("token")]
 public class TokenController : ControllerBase
 {
-    private static readonly Regex _symbolRegex = new("^[a-z0-9]{1,35}$");
-
     private readonly ILedgerStateQuerier _ledgerStateQuerier;
     private readonly ITokenQuerier _tokenQuerier;
     private readonly INetworkConfigurationProvider _networkConfigurationProvider;

--- a/src/GatewayAPI/Database/TokenQuerier.cs
+++ b/src/GatewayAPI/Database/TokenQuerier.cs
@@ -80,6 +80,8 @@ public interface ITokenQuerier
     Task<Gateway.Token> GetTokenInfoAtState(string tokenRri, Gateway.LedgerState ledgerState);
 
     Task<CreatedTokenData> GetCreatedTokenProperties(string tokenRri, LedgerOperationGroup operationGroup);
+
+    Task<bool> DoesTokenExist(string tokenRri, Gateway.LedgerState ledgerState);
 }
 
 public record CreatedTokenData(Gateway.TokenProperties TokenProperties, Gateway.TokenAmount TokenSupply);
@@ -142,6 +144,12 @@ public class TokenQuerier : ITokenQuerier
             : (await GetFixedTokenMintInOperationGroup(tokenRri, operationGroup)).AsGatewayTokenAmount(tokenRri);
 
         return new CreatedTokenData(tokenProperties, tokenSupplyAmount);
+    }
+
+    public async Task<bool> DoesTokenExist(string tokenRri, Gateway.LedgerState ledgerState)
+    {
+        var resource = await _dbContext.Resource(tokenRri, ledgerState._Version).SingleOrDefaultAsync();
+        return resource != null;
     }
 
     private async Task<TokenAmount> GetFixedTokenMintInOperationGroup(string tokenRri, LedgerOperationGroup operationGroup)


### PR DESCRIPTION
* Validate token URLs
* Throw a helpful validation error when using decimals in an amount
* Throw an RRI already created error on token creation (instead of Core API exception)
* Check the fee payer account for Register/Unregister has the same public key as the validator being registered/unregistered