### PR TITLE
Add parameters to allow for sleeping between batches to share resource use during sync

### DIFF
--- a/src/DataAggregator/Configuration/Models/LedgerConfirmationConfiguration.cs
+++ b/src/DataAggregator/Configuration/Models/LedgerConfirmationConfiguration.cs
@@ -62,6 +62,8 @@
  * permissions under this License.
  */
 
+using NodaTime;
+
 namespace DataAggregator.Configuration.Models;
 
 public record LedgerConfirmationConfiguration
@@ -94,7 +96,29 @@ public record LedgerConfirmationConfiguration
     /// The maximum batch to send to the ledger extension service for committing.
     /// </summary>
     [ConfigurationKeyName("MaxCommitBatchSize")]
-    public long MaxCommitBatchSize { get; set; } = 1000;
+    public long MaxCommitBatchSize { get; set; } = 300;
+
+    /// <summary>
+    /// Gets or sets LargeBatchSizeToAddDelay.
+    /// LargeBatchSizeToAddDelay determines if the DelayBetweenLargeBatchesMilliseconds should be added.
+    /// This is only relevant if a DelayBetweenLargeBatchesMilliseconds is configured.
+    /// This property essentially determines if the syncing is in large batches (catch-up syncing) or small batches
+    /// (likely realtime syncing, where resource use isn't full and adding a delay isn't so necessary).
+    /// The delay is only added when the ingested batch size exceeds this threshold. This should be set to be less than
+    /// or equal to MaxCommitBatchSize.
+    /// </summary>
+    [ConfigurationKeyName("LargeBatchSizeToAddDelay")]
+    public long LargeBatchSizeToAddDelay { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets DelayBetweenLargeBatchesMilliseconds.
+    /// This delay allows for a simple means to limit the resource usage of the Gateway / DB during syncing.
+    /// See also LargeBatchSizeToAddDelay.
+    /// </summary>
+    [ConfigurationKeyName("DelayBetweenLargeBatchesMilliseconds")]
+    public long DelayBetweenLargeBatchesMilliseconds { get; set; } = 0;
+
+    public Duration DelayBetweenLargeBatches => Duration.FromMilliseconds(DelayBetweenLargeBatchesMilliseconds);
 
     /// <summary>
     /// Gets or sets MaxTransactionPipelineSizePerNode.

--- a/src/DataAggregator/appsettings.json
+++ b/src/DataAggregator/appsettings.json
@@ -24,7 +24,9 @@
         "OnlyUseSufficientlySyncedUpNodesForQuorumCalculation": true,
         "SufficientlySyncedStateVersionThreshold": 1000,
         "MaxCommitBatchSize": 1000,
-        "MaxTransactionPipelineSizePerNode": 3000
+        "MaxTransactionPipelineSizePerNode": 3000,
+        "LargeBatchSizeToAddDelay": 500,
+        "DelayBetweenLargeBatchesMilliseconds": 0
     },
     "TransactionAssertions": {
         "AssertDownedSubstatesMatchDownFromCoreApi": false,


### PR DESCRIPTION
This is a "simple" scheme to try to reduce steam-rolling of the IO resources on the Gateway Aggregator/DB; by allowing the configuration of delay between ingestion batches.

See LedgerConfirmation.LargeBatchSizeToAddDelay and LedgerConfirmation.DelayBetweenLargeBatchesMilliseconds

Note that during batch ingestion, full resources are still used. A rough usage of these parameters for this use might set the following in the `LedgerConfirmation` section:
* MaxCommitBatchSize: 500
* LargeBatchSizeToAddDelay: 500
* DelayBetweenLargeBatchesMilliseconds: 1000

Configured via environment variables, these look something like:  `RADIX_NG_AGGREGATOR__LedgerConfirmation__MaxCommitBatchSize=500`