### PR TITLE
feat: Enable HttpClient response decompression for Core API 

### DIFF
--- a/src/DataAggregator/DependencyInjection/DefaultKernel.cs
+++ b/src/DataAggregator/DependencyInjection/DefaultKernel.cs
@@ -228,6 +228,8 @@ public class DefaultKernel
             httpClientHandler.Proxy = new WebProxy(httpProxyAddress);
         }
 
+        httpClientHandler.AutomaticDecompression = DecompressionMethods.All;
+
         return httpClientHandler;
     }
 }

--- a/src/GatewayAPI/DependencyInjection/DefaultKernel.cs
+++ b/src/GatewayAPI/DependencyInjection/DefaultKernel.cs
@@ -199,6 +199,8 @@ public class DefaultKernel
             httpClientHandler.Proxy = new WebProxy(httpProxyAddress);
         }
 
+        httpClientHandler.AutomaticDecompression = DecompressionMethods.All;
+
         return httpClientHandler;
     }
 }


### PR DESCRIPTION
(ie brotli/gzip/deflate headers - see https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler.automaticdecompression?view=net-7.0 )