### PR TITLE
tweak: Update current validator stake mapping query

### DIFF
--- a/src/Common/Database/DbQueryExtensions.cs
+++ b/src/Common/Database/DbQueryExtensions.cs
@@ -335,30 +335,6 @@ INNER JOIN LATERAL (
 ");
     }
 
-    public static IQueryable<ValidatorStakeHistory> ValidatorStakeHistoryAtVersionForValidatorAddressesWithIncludedValidator<TDbContext>(
-        this TDbContext dbContext,
-        List<string> validatorAddresses,
-        long stateVersion
-    )
-        where TDbContext : CommonDbContext
-    {
-        return dbContext.Validators
-            .Where(v => validatorAddresses.Contains(v.Address) && v.FromStateVersion <= stateVersion)
-            .Select(v => v.Id)
-            .Select(validatorId =>
-                dbContext.Set<ValidatorStakeHistory>()
-                    .Where(h =>
-                        h.ValidatorId == validatorId
-                        && h.FromStateVersion <= stateVersion
-                    )
-                    .OrderByDescending(h => h.FromStateVersion)
-                    .Include(v => v.Validator)
-                    .FirstOrDefault()
-            )
-            .Where(vsh => vsh != null)
-            .Select(vsh => vsh!);
-    }
-
     public static IQueryable<ValidatorStakeHistory> ValidatorStakeHistoryAtVersionForValidatorIds<TDbContext>(
         this TDbContext dbContext,
         List<long> validatorIds,


### PR DESCRIPTION
Update current validator stake mapping query to have a better query plan.

This query is used during stake/unstake finalization to create an estimated XRD-worth of the stake units - for the receipt which is stored in the pending transaction.

I've changed the query from an EF-Core query (which [I believe suffers from this issue](https://github.com/dotnet/efcore/issues/17936#issuecomment-1009011840)) to the manual query that's already been tuned to be very performant for the validators endpoint.

I'm talking to Theo to test that this change is (a) functional, and (b) more performant.